### PR TITLE
Fixing logging to reconnect more quickly when it hangs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    docker_cloud_service_runner (0.1.1)
+    docker_cloud_service_runner (0.0.2)
       rest-client (= 2.0)
       websocket-eventmachine-client (= 1.2)
 
@@ -9,9 +9,9 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.5)
-    domain_name (0.5.20161129)
+    domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
-    eventmachine (1.2.1)
+    eventmachine (1.2.3)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     mime-types (3.1)
@@ -38,8 +38,8 @@ GEM
     rspec-support (3.5.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
-    websocket (1.2.3)
+    unf_ext (0.0.7.4)
+    websocket (1.2.4)
     websocket-eventmachine-base (1.2.0)
       eventmachine (~> 1.0)
       websocket (~> 1.0)
@@ -58,4 +58,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.13.6
+   1.14.6

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Or install it yourself as:
 
 ## Usage
 
+### General usage information
+
+As this runs, it uses websockets to pull log data from Docker Cloud.  This fails often, so we check every 70 seconds to see if we've stopped receiving logs and reconnect if necessary.  In order to prevent unnecessary reconnects, you should output more often than once every 70 seconds.
+
 ### Running as a user
 ```
 service = {

--- a/lib/docker_cloud_service_runner/version.rb
+++ b/lib/docker_cloud_service_runner/version.rb
@@ -1,3 +1,3 @@
 module DockerCloudServiceRunner
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end

--- a/spec/integration/docker_cloud_service_runner_spec.rb
+++ b/spec/integration/docker_cloud_service_runner_spec.rb
@@ -1,18 +1,18 @@
 require "spec_helper"
 
 describe DockerCloudServiceRunner do
-  # it "successfully runs a service as a user" do
-  #   username = ENV["DOCKER_CLOUD_SERVICE_RUNNER_USERNAME"]
-  #   apikey = ENV["DOCKER_CLOUD_SERVICE_RUNNER_APIKEY"]
-  #   service = {
-  #     :image => "debian:jessie",
-  #     :name => "dc-runner-test-user",
-  #     :run_command => "timeout 30s sh -c 'for i in `seq 1 3`; do echo $i; sleep 1; done'"
-  #   }
+  it "successfully runs a service as a user" do
+    username = ENV["DOCKER_CLOUD_SERVICE_RUNNER_USERNAME"]
+    apikey = ENV["DOCKER_CLOUD_SERVICE_RUNNER_APIKEY"]
+    service = {
+      :image => "debian:jessie",
+      :name => "dc-runner-test-user",
+      :run_command => "timeout 30s sh -c 'for i in `seq 1 3`; do echo $i; sleep 1; done'"
+    }
 
-  #   exit_data = DockerCloudServiceRunner::createAndRunService(username, apikey, service)
-  #   expect(exit_data[:exit_code]).to eq(0)
-  # end
+    exit_data = DockerCloudServiceRunner::createAndRunService(username, apikey, service)
+    expect(exit_data[:exit_code]).to eq(0)
+  end
 
   it "successfully runs a service as an organization" do
     username = ENV["DOCKER_CLOUD_SERVICE_RUNNER_USERNAME"] || "username"


### PR DESCRIPTION
* Moved everything inside the thread into a function, so that we can recall the function without creating a new thread each time
* Added a periodic_timer that checks to ensure we are still seeing new logs.  Checking every 70 seconds.  This allows it to not reconnect if we have output once a minute.